### PR TITLE
2차 인증기능에 대한 기능 수정

### DIFF
--- a/src/main/java/pjh5365/linuxserviceweb/domain/auth/filter/SecondaryAuthFilter.java
+++ b/src/main/java/pjh5365/linuxserviceweb/domain/auth/filter/SecondaryAuthFilter.java
@@ -27,10 +27,7 @@ public class SecondaryAuthFilter extends AbstractAuthenticationProcessingFilter 
         String password = request.getParameter("password");
         String emailAuth = request.getParameter("email-auth");
 
-
-        String getCode = secondaryAuthService.getCode();  // 인증번호 가져오기
-
-        if(!getCode.matches(emailAuth))    // 2차 인증 코드와 맞지않다면 로그인에 실패하기 위해 비밀번호를 틀리게 설정
+        if(!secondaryAuthService.checkSecondaryCode(username, emailAuth))    // 2차 인증 코드와 맞지않다면 로그인에 실패하기 위해 비밀번호를 틀리게 설정
             password = password + "!!!!";
 
         UsernamePasswordAuthenticationToken authenticationToken = UsernamePasswordAuthenticationToken.unauthenticated(username.trim(), password);

--- a/src/main/java/pjh5365/linuxserviceweb/domain/auth/service/SecondaryAuthService.java
+++ b/src/main/java/pjh5365/linuxserviceweb/domain/auth/service/SecondaryAuthService.java
@@ -2,9 +2,15 @@ package pjh5365.linuxserviceweb.domain.auth.service;
 
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import pjh5365.linuxserviceweb.domain.auth.GenerateCode;
 import pjh5365.linuxserviceweb.domain.mail.Mail;
+import pjh5365.linuxserviceweb.domain.user.UserEntity;
+import pjh5365.linuxserviceweb.repository.UserRepository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
 
 @Slf4j
 @Getter
@@ -13,15 +19,38 @@ public class SecondaryAuthService {
 
     // 2. 생성된 코드를 필터에서 가져다 쓰기
     private String code;
+    private final UserRepository userRepository;
+
+    @Autowired
+    public SecondaryAuthService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
 
     public void sendSecondaryAuth(String email) {    // 1. 해당 메서드가 호출되면 코드를 생성하고
         Mail mail = new Mail();
         code = GenerateCode.generate();
         try {
             mail.sendEmailAuth(email, code);
+            UserEntity user = userRepository.findByEmail(email);
+            user.setSecondaryCode(code);    // 인증코드 설정
+            user.setExpiredAt(LocalDateTime.now().plusMinutes(5));  // 유효기간은 지금으로 부터 +5분
+            userRepository.save(user);  // 인증코드와 유효기간 DB 에 업로드
         } catch (Exception e) {
             log.error("2차 로그인에 필요한 인증코드를 전송하는데 실패했습니다. : {}", e.getMessage());
             throw new RuntimeException();
+        }
+    }
+
+    public boolean checkSecondaryCode(String username, String code) {
+        Optional<UserEntity> optionalUser = userRepository.findByUsername(username);
+
+        if(optionalUser.isEmpty()) {    // 사용자 정보를 찾지 못하는 경우
+            return false;
+        }
+        else {
+            UserEntity user = optionalUser.get();
+            // 유효기간과 인증코드를 확인한 결과를 리턴
+            return user.getSecondaryCode().matches(code) && LocalDateTime.now().isBefore(user.getExpiredAt());
         }
     }
 }

--- a/src/main/java/pjh5365/linuxserviceweb/domain/mail/Mail.java
+++ b/src/main/java/pjh5365/linuxserviceweb/domain/mail/Mail.java
@@ -74,13 +74,14 @@ public class Mail {
         String path = "/home/pibber/sendmail/";
         String mailFile = "emailAuthCode.txt";
         StringBuilder content = new StringBuilder();
-        content.append("로그인을 위한 2차 인증번호입니다.").append("\n");
-        content.append(code);
+        content.append("pibber 서비스의 로그인을 위한 2차 인증번호입니다.").append("\n\n");
+        content.append(code).append("\n\n");
+        content.append("인증번호는 5분간 유효합니다. \n").append("\n");
         try {
             BufferedWriter bufferedWriter = new BufferedWriter(new FileWriter(path + mailFile));    // 메일을 보내기전에 보낼 내용을 다른 파일에 미리 저장하고
             bufferedWriter.write("To: " + to);
             bufferedWriter.newLine();
-            bufferedWriter.write("Subject: 로그인 2차 인증 번호");
+            bufferedWriter.write("Subject: pibber 서비스의 로그인 2차 인증 번호");
             bufferedWriter.newLine();
             bufferedWriter.newLine();
             bufferedWriter.write(String.valueOf(content));

--- a/src/main/java/pjh5365/linuxserviceweb/domain/user/UserEntity.java
+++ b/src/main/java/pjh5365/linuxserviceweb/domain/user/UserEntity.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.time.LocalDateTime;
+
 @Setter
 @Getter
 @Entity
@@ -17,6 +19,8 @@ public class UserEntity {
     private String name;
     private String email;
     private String password;
+    private String secondaryCode;
+    private LocalDateTime expiredAt;
 
     @Enumerated(EnumType.STRING)    // enum 을 데이터베이스에 저장하기 위한 어노테이션
     private UserRole role;

--- a/src/main/java/pjh5365/linuxserviceweb/repository/UserRepository.java
+++ b/src/main/java/pjh5365/linuxserviceweb/repository/UserRepository.java
@@ -7,7 +7,7 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<UserEntity, Long> {
     Optional<UserEntity> findByUsername(String username);
+    UserEntity findByEmail(String email);
     boolean existsByUsername(String username);
-
     boolean existsByEmail(String email);
 }

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -46,6 +46,9 @@
                                 <input class="form-control" id="inputPassword" name="password" type="password" required th:value="${secondaryAuth} ? ${password} : ''" />
                                 <label for="inputPassword">비밀번호</label>
                             </div>
+                            <span th:if="${secondaryAuth}">
+                                <p id="secondaryCheck" class="alert alert-info">메일함의 인증번호를 입력해주세요.</p>
+                            </span>
                             <div class="form-floating mb-3" th:if="${secondaryAuth}">   <!-- 2차 인증을 요청하는 경우 -->
                                 <input class="form-control" id="email-auth" name="email-auth" type="text" required  />
                                 <label for="email-auth">이메일 인증번호</label>


### PR DESCRIPTION
2차 인증에 발생했던 버그를 수정하여 개별 사용자가 각자의 인증번호를 데이터베이스에 저장하고 그에 해당하는 유효기간을 가지도록 수정해주었다.

This closes: #24 